### PR TITLE
Revert "Mac OS X option"

### DIFF
--- a/mk.bash
+++ b/mk.bash
@@ -6,9 +6,6 @@ OS=$(uname -s)
 if [[ $OS = "OpenBSD" ]];then
 	echo "using OpenBSD Makefile."
 	make -f makefile.openbsd
-elif [[ $OS = "Darwin" ]];then
-        echo "using Mac OS X Makefile."
-        make -f makefile.macosx
 else
 	echo "using Linux Makefile."
 	make -f makefile


### PR DESCRIPTION
This reverts commit 69af8d5adb3795c5bfad8349b9e0b2b00611aa30.

`makefile.macosx` doesn't exist in `master` branch and `makefile` works well in Mac OS X el capitan.

```
% gcc -v
Configured with: --prefix=/Applications/Xcode.app/Contents/Developer/usr --with-gxx-include-dir=/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.11.sdk/usr/include/c++/4.2.1
Apple LLVM version 7.0.2 (clang-700.1.81)
Target: x86_64-apple-darwin15.3.0
Thread model: posix
```