### PR TITLE
fix warnings caused by compiling world.c

### DIFF
--- a/world.c
+++ b/world.c
@@ -747,7 +747,7 @@ ctr_object* ctr_send_message(ctr_object* receiverObject, char* message, long vle
  * Assigns a value to a variable in the current context.
  */
 ctr_object* ctr_assign_value(ctr_object* key, ctr_object* o) {
-	ctr_object* object;
+	ctr_object* object = NULL;
 	if (CtrStdError) return CtrStdNil;
 	key->info.sticky = 0;
 	if (o->info.type == CTR_OBJECT_TYPE_OTOBJECT || o->info.type == CTR_OBJECT_TYPE_OTMISC || o->info.type == CTR_OBJECT_TYPE_OTARRAY || o->info.type == CTR_OBJECT_TYPE_OTNIL) {
@@ -783,7 +783,7 @@ ctr_object* ctr_assign_value(ctr_object* key, ctr_object* o) {
  * Assigns a value to a property of an object. 
  */
 ctr_object* ctr_assign_value_to_my(ctr_object* key, ctr_object* o) {
-	ctr_object* object;
+	ctr_object* object = NULL;
 	ctr_object* my = ctr_find(ctr_build_string("me", 2));
 	if (CtrStdError) return CtrStdNil;
 	key->info.sticky = 0;
@@ -819,7 +819,7 @@ ctr_object* ctr_assign_value_to_my(ctr_object* key, ctr_object* o) {
  * Assigns a value to a local of an object. 
  */
 ctr_object* ctr_assign_value_to_local(ctr_object* key, ctr_object* o) {
-	ctr_object* object;
+	ctr_object* object = NULL;
 	ctr_object* context;
 	if (CtrStdError) return CtrStdNil;
 	context = ctr_contexts[ctr_context_id];


### PR DESCRIPTION
fix to remove `variable 'object' is used uninitialized` warnings.

```
gcc -mtune=native -Wall -c world.c
world.c:753:6: warning: variable 'object' is used uninitialized whenever 'if' condition is true [-Wsometimes-uninitialized]
  ...o->info.type == CTR_OBJECT_TYPE_OTOBJECT || o->info.type == CTR_OBJECT_TYPE_OTMISC || o->info.type == CTR_OBJECT_TYPE_OTARRAY || o->info.type == CTR_OBJECT_TYPE_OTNIL) {
     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
world.c:776:9: note: uninitialized use occurs here
        return object;
               ^~~~~~
world.c:753:2: note: remove the 'if' if its condition is always false
  ...if (o->info.type == CTR_OBJECT_TYPE_OTOBJECT || o->info.type == CTR_OBJECT_TYPE_OTMISC || o->info.type == CTR_OBJECT_TYPE_OTARRAY || o->info.type == CTR_OBJECT_TYPE_OTNIL) {
     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
world.c:753:6: warning: variable 'object' is used uninitialized whenever '||' condition is true [-Wsometimes-uninitialized]
  ...o->info.type == CTR_OBJECT_TYPE_OTOBJECT || o->info.type == CTR_OBJECT_TYPE_OTMISC || o->info.type == CTR_OBJECT_TYPE_OTARRAY...
     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
world.c:776:9: note: uninitialized use occurs here
        return object;
               ^~~~~~
world.c:753:6: note: remove the '||' if its condition is always false
  ...o->info.type == CTR_OBJECT_TYPE_OTOBJECT || o->info.type == CTR_OBJECT_TYPE_OTMISC || o->info.type == CTR_OBJECT_TYPE_OTARRAY ||...
     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
world.c:753:6: warning: variable 'object' is used uninitialized whenever '||' condition is true [-Wsometimes-uninitialized]
        if (o->info.type == CTR_OBJECT_TYPE_OTOBJECT || o->info.type == CTR_OBJECT_TYPE_OTMISC || o->info.type == CTR_OBJECT_...
            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
world.c:776:9: note: uninitialized use occurs here
        return object;
               ^~~~~~
world.c:753:6: note: remove the '||' if its condition is always false
        if (o->info.type == CTR_OBJECT_TYPE_OTOBJECT || o->info.type == CTR_OBJECT_TYPE_OTMISC || o->info.type == CTR_OBJECT_...
            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
world.c:753:6: warning: variable 'object' is used uninitialized whenever '||' condition is true [-Wsometimes-uninitialized]
        if (o->info.type == CTR_OBJECT_TYPE_OTOBJECT || o->info.type == CTR_OBJECT_TYPE_OTMISC || o->info.type == CTR_OBJECT_...
            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
world.c:776:9: note: uninitialized use occurs here
        return object;
               ^~~~~~
world.c:753:6: note: remove the '||' if its condition is always false
        if (o->info.type == CTR_OBJECT_TYPE_OTOBJECT || o->info.type == CTR_OBJECT_TYPE_OTMISC || o->info.type == CTR_OBJECT_...
            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
world.c:750:20: note: initialize the variable 'object' to silence this warning
        ctr_object* object;
                          ^
                           = NULL
world.c:790:6: warning: variable 'object' is used uninitialized whenever 'if' condition is true [-Wsometimes-uninitialized]
  ...o->info.type == CTR_OBJECT_TYPE_OTOBJECT || o->info.type == CTR_OBJECT_TYPE_OTMISC || o->info.type == CTR_OBJECT_TYPE_OTARRAY || o->info.type == CTR_OBJECT_TYPE_OTNIL) {
     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
world.c:813:9: note: uninitialized use occurs here
        return object;
               ^~~~~~
world.c:790:2: note: remove the 'if' if its condition is always false
  ...if (o->info.type == CTR_OBJECT_TYPE_OTOBJECT || o->info.type == CTR_OBJECT_TYPE_OTMISC || o->info.type == CTR_OBJECT_TYPE_OTARRAY || o->info.type == CTR_OBJECT_TYPE_OTNIL) {
     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
world.c:790:6: warning: variable 'object' is used uninitialized whenever '||' condition is true [-Wsometimes-uninitialized]
  ...o->info.type == CTR_OBJECT_TYPE_OTOBJECT || o->info.type == CTR_OBJECT_TYPE_OTMISC || o->info.type == CTR_OBJECT_TYPE_OTARRAY...
     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
world.c:813:9: note: uninitialized use occurs here
        return object;
               ^~~~~~
world.c:790:6: note: remove the '||' if its condition is always false
  ...o->info.type == CTR_OBJECT_TYPE_OTOBJECT || o->info.type == CTR_OBJECT_TYPE_OTMISC || o->info.type == CTR_OBJECT_TYPE_OTARRAY ||...
     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
world.c:790:6: warning: variable 'object' is used uninitialized whenever '||' condition is true [-Wsometimes-uninitialized]
        if (o->info.type == CTR_OBJECT_TYPE_OTOBJECT || o->info.type == CTR_OBJECT_TYPE_OTMISC || o->info.type == CTR_OBJECT_...
            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
world.c:813:9: note: uninitialized use occurs here
        return object;
               ^~~~~~
world.c:790:6: note: remove the '||' if its condition is always false
        if (o->info.type == CTR_OBJECT_TYPE_OTOBJECT || o->info.type == CTR_OBJECT_TYPE_OTMISC || o->info.type == CTR_OBJECT_...
            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
world.c:790:6: warning: variable 'object' is used uninitialized whenever '||' condition is true [-Wsometimes-uninitialized]
        if (o->info.type == CTR_OBJECT_TYPE_OTOBJECT || o->info.type == CTR_OBJECT_TYPE_OTMISC || o->info.type == CTR_OBJECT_...
            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
world.c:813:9: note: uninitialized use occurs here
        return object;
               ^~~~~~
world.c:790:6: note: remove the '||' if its condition is always false
        if (o->info.type == CTR_OBJECT_TYPE_OTOBJECT || o->info.type == CTR_OBJECT_TYPE_OTMISC || o->info.type == CTR_OBJECT_...
            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
world.c:786:20: note: initialize the variable 'object' to silence this warning
        ctr_object* object;
                          ^
                           = NULL
world.c:827:6: warning: variable 'object' is used uninitialized whenever 'if' condition is true [-Wsometimes-uninitialized]
  ...o->info.type == CTR_OBJECT_TYPE_OTOBJECT || o->info.type == CTR_OBJECT_TYPE_OTMISC || o->info.type == CTR_OBJECT_TYPE_OTARRAY || o->info.type == CTR_OBJECT_TYPE_OTNIL) {
     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
world.c:850:9: note: uninitialized use occurs here
        return object;
               ^~~~~~
world.c:827:2: note: remove the 'if' if its condition is always false
  ...if (o->info.type == CTR_OBJECT_TYPE_OTOBJECT || o->info.type == CTR_OBJECT_TYPE_OTMISC || o->info.type == CTR_OBJECT_TYPE_OTARRAY || o->info.type == CTR_OBJECT_TYPE_OTNIL) {
     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
world.c:827:6: warning: variable 'object' is used uninitialized whenever '||' condition is true [-Wsometimes-uninitialized]
  ...o->info.type == CTR_OBJECT_TYPE_OTOBJECT || o->info.type == CTR_OBJECT_TYPE_OTMISC || o->info.type == CTR_OBJECT_TYPE_OTARRAY...
     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
world.c:850:9: note: uninitialized use occurs here
        return object;
               ^~~~~~
world.c:827:6: note: remove the '||' if its condition is always false
  ...o->info.type == CTR_OBJECT_TYPE_OTOBJECT || o->info.type == CTR_OBJECT_TYPE_OTMISC || o->info.type == CTR_OBJECT_TYPE_OTARRAY ||...
     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
world.c:827:6: warning: variable 'object' is used uninitialized whenever '||' condition is true [-Wsometimes-uninitialized]
        if (o->info.type == CTR_OBJECT_TYPE_OTOBJECT || o->info.type == CTR_OBJECT_TYPE_OTMISC || o->info.type == CTR_OBJECT_...
            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
world.c:850:9: note: uninitialized use occurs here
        return object;
               ^~~~~~
world.c:827:6: note: remove the '||' if its condition is always false
        if (o->info.type == CTR_OBJECT_TYPE_OTOBJECT || o->info.type == CTR_OBJECT_TYPE_OTMISC || o->info.type == CTR_OBJECT_...
            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
world.c:827:6: warning: variable 'object' is used uninitialized whenever '||' condition is true [-Wsometimes-uninitialized]
        if (o->info.type == CTR_OBJECT_TYPE_OTOBJECT || o->info.type == CTR_OBJECT_TYPE_OTMISC || o->info.type == CTR_OBJECT_...
            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
world.c:850:9: note: uninitialized use occurs here
        return object;
               ^~~~~~
world.c:827:6: note: remove the '||' if its condition is always false
        if (o->info.type == CTR_OBJECT_TYPE_OTOBJECT || o->info.type == CTR_OBJECT_TYPE_OTMISC || o->info.type == CTR_OBJECT_...
            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
world.c:822:20: note: initialize the variable 'object' to silence this warning
        ctr_object* object;
                          ^
                           = NULL
12 warnings generated.
```