### PR TITLE
remove unused variable 'pathName'

### DIFF
--- a/util.c
+++ b/util.c
@@ -194,7 +194,6 @@ void ctr_internal_debug_tree(ctr_tnode* ti, int indent) {
 void* ctr_internal_plugin_find(ctr_object* key) {
 	ctr_object* modNameObject = ctr_internal_cast2string(key);
 	void* handle;
-	char  pathName[1024];
 	char  pathNameMod[1024];
 	char* modName;
 	char* modNameLow;

--- a/util.c
+++ b/util.c
@@ -197,12 +197,10 @@ void* ctr_internal_plugin_find(ctr_object* key) {
 	char  pathNameMod[1024];
 	char* modName;
 	char* modNameLow;
-	char* realPathModName = NULL;
 	CTR_2CSTR(modName, modNameObject);
 	modNameLow = modName;
 	for ( ; *modNameLow; ++modNameLow) *modNameLow = tolower(*modNameLow);
 	snprintf(pathNameMod, 1024,"mods/%s/libctr%s.so", modName, modName);
-	realPathModName = realpath(pathNameMod, NULL);
 	if (access(pathNameMod, F_OK) == -1) return NULL;
 	handle =  dlopen(pathNameMod, RTLD_NOW);
 	return handle;


### PR DESCRIPTION
```
util.c:197:8: warning: unused variable 'pathName' [-Wunused-variable]
        char  pathName[1024];
              ^
```