### PR TITLE
'pathName' variable is not used at last

### DIFF
--- a/util.c
+++ b/util.c
@@ -194,7 +194,6 @@ void ctr_internal_debug_tree(ctr_tnode* ti, int indent) {
 void* ctr_internal_plugin_find(ctr_object* key) {
 	ctr_object* modNameObject = ctr_internal_cast2string(key);
 	void* handle;
-	char  pathName[1024];
 	char  pathNameMod[1024];
 	char* modName;
 	char* modNameLow;


### PR DESCRIPTION
```
util.c:197:8: warning: unused variable 'pathName' [-Wunused-variable]
        char  pathName[1024];
              ^
```