### PR TITLE
ctr_clex_is_delimiter shouldn't inline (at Darwin)

### DIFF
--- a/lexer.c
+++ b/lexer.c
@@ -48,7 +48,7 @@ char* ctr_clex_desc_tok_unknown = "(unknown token)";
  *
  * @return uint8_t
  */
-inline uint8_t ctr_clex_is_delimiter( char symbol ) {
+uint8_t ctr_clex_is_delimiter( char symbol ) {
 
 	return (
 	   symbol == '('


### PR DESCRIPTION
```
gcc siphash.o utf8.o memory.o util.o base.o collections.o file.o system.o world.o lexer.o parser.o walker.o citrine.o -rdynamic -lm -ldl -o ctr -v
Apple LLVM version 7.3.0 (clang-703.0.31)
Target: x86_64-apple-darwin15.6.0
Thread model: posix
InstalledDir: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin
 "/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/ld" -demangle -export_dynamic -dynamic -arch x86_64 -macosx_version_min 10.11.0 -o ctr siphash.o utf8.o memory.o util.o base.o collections.o file.o system.o world.o lexer.o parser.o walker.o citrine.o -lm -ldl -lSystem /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../lib/clang/7.3.0/lib/darwin/libclang_rt.osx.a
Undefined symbols for architecture x86_64:
  "_ctr_clex_is_delimiter", referenced from:
      _ctr_clex_tok in lexer.o
ld: symbol(s) not found for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```