### PR TITLE
remove unused variables warnings

### DIFF
--- a/parser.c
+++ b/parser.c
@@ -506,7 +506,7 @@ ctr_tnode* ctr_cparse_expr(int mode) {
 		e->type = CTR_AST_NODE_EXPRMESSAGE;
 		nodes = ctr_cparse_messages(r, mode);
 		if (nodes == NULL) {
-			int t = ctr_clex_tok();
+			ctr_clex_tok();
 			ctr_clex_putback();
 			return r; /* no messages, then just return receiver (might be in case of argument). */
 		}

--- a/world.c
+++ b/world.c
@@ -263,7 +263,6 @@ char* ctr_internal_memmem(char* haystack, long hlen, char* needle, long nlen, in
 		begin = haystack + hlen - nlen;
 		last = haystack - 1;
 	}
-	char* q = calloc( sizeof(char), nlen );
 	for(cur = begin; cur!=last; cur += step) {
 		if (memcmp(cur,needle,nlen) == 0) return cur;
 	}


### PR DESCRIPTION
```
gcc -mtune=native -Wall -c world.c
world.c:266:8: warning: unused variable 'q' [-Wunused-variable]
        char* q = calloc( sizeof(char), nlen );
              ^
```

```
gcc -mtune=native -Wall -c parser.c
parser.c:509:8: warning: unused variable 't' [-Wunused-variable]
                        int t = ctr_clex_tok();
```