### PR TITLE
remove format specifies type unmatch warning

### DIFF
--- a/citrine.c
+++ b/citrine.c
@@ -78,7 +78,7 @@ int main(int argc, char* argv[]) {
 	ctr_heap_free_rest();
 	//For memory profiling
 	if ( ctr_gc_alloc != 0 ) {
-		printf( "[WARNING] Citrine has detected an internal memory leak of: %lu bytes.\n", ctr_gc_alloc );
+		printf( "[WARNING] Citrine has detected an internal memory leak of: %llu bytes.\n", ctr_gc_alloc );
 		exit(1);
 	}
 	exit(0);


### PR DESCRIPTION
```
citrine.c:81:86: warning: format specifies type 'unsigned long' but the argument has type 'uint64_t' (aka 'unsigned long long')
      [-Wformat]
                printf( "[WARNING] Citrine has detected an internal memory leak of: %lu bytes.\n", ctr_gc_alloc );
                                                                                    ~~~            ^~~~~~~~~~~~
                                                                                    %llu
```