### PR TITLE
Remove format warning and fix test0156

### DIFF
--- a/citrine.c
+++ b/citrine.c
@@ -3,6 +3,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
+#include <stddef.h>
 #include <ctype.h>
 #include <stdarg.h>
 #include <math.h>
@@ -77,7 +78,7 @@ int main(int argc, char* argv[]) {
 	ctr_heap_free_rest();
 	//For memory profiling
 	if ( ctr_gc_alloc != 0 ) {
-		printf( "[WARNING] Citrine has detected an internal memory leak of: %llu bytes.\n", ctr_gc_alloc );
+		printf( "[WARNING] Citrine has detected an internal memory leak of: %" PRIu64 " bytes.\n", ctr_gc_alloc );
 		exit(1);
 	}
 	exit(0);

--- a/citrine.c
+++ b/citrine.c
@@ -3,7 +3,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
-#include <stddef.h>
+#include <inttypes.h>
 #include <ctype.h>
 #include <stdarg.h>
 #include <math.h>

--- a/world.c
+++ b/world.c
@@ -418,6 +418,7 @@ void ctr_open_context() {
 	if (ctr_context_id >= 299) {
 		CtrStdFlow = ctr_build_string_from_cstring( "Too many nested calls." );
 		CtrStdFlow->info.sticky = 1;
+		return;
 	}
 	context = ctr_internal_create_object(CTR_OBJECT_TYPE_OTOBJECT);
 	context->info.sticky = 1;


### PR DESCRIPTION
This pull request fixes test0156 again, because somehow the addition of the `return` statement in #80 is gone.

This also uses the PRIu64 macro to definitely squash the warning about using the incorrect type, also seen in #82 . On my machine, an unsigned 64 bit integer is `unsigned long` instead of `unsigned long long`. To resolve these differences, there are a number of macros one can use from the inttypes.h header.