### PR TITLE
Collection type methods

### DIFF
--- a/citrine.h
+++ b/citrine.h
@@ -473,6 +473,7 @@ ctr_object* ctr_block_times(ctr_object* myself, ctr_argument* argumentList);
  */
 ctr_object* ctr_array_new(ctr_object* myclass, ctr_argument* argumentList);
 ctr_object* ctr_array_new_and_push(ctr_object* myself, ctr_argument* argumentList);
+ctr_object* ctr_array_type(ctr_object* myself, ctr_argument* argumentList);
 ctr_object* ctr_array_push(ctr_object* myself, ctr_argument* argumentList);
 ctr_object* ctr_array_unshift(ctr_object* myself, ctr_argument* argumentList);
 ctr_object* ctr_array_shift(ctr_object* myself, ctr_argument* argumentList);
@@ -494,6 +495,7 @@ ctr_object* ctr_array_product(ctr_object* myself, ctr_argument* argumentList);
  * HashMap Interface
  */
 ctr_object* ctr_map_new(ctr_object* myself, ctr_argument* argumentList);
+ctr_object* ctr_map_type(ctr_object* myself, ctr_argument* argumentList);
 ctr_object* ctr_map_put(ctr_object* myself, ctr_argument* argumentList);
 ctr_object* ctr_map_get(ctr_object* myself, ctr_argument* argumentList);
 ctr_object* ctr_map_count(ctr_object* myself, ctr_argument* argumentList);

--- a/collections.c
+++ b/collections.c
@@ -37,6 +37,16 @@ ctr_object* ctr_array_new(ctr_object* myclass, ctr_argument* argumentList) {
 }
 
 /**
+ * [Array] type
+ *
+ * Returns the string 'Array'.
+ *
+ **/
+ctr_object* ctr_array_type(ctr_object* myself, ctr_argument* argumentList) {
+	return ctr_build_string_from_cstring("Array");
+}
+
+/**
  * [Array] push: [Element]
  *
  * Pushes an element on top of the array.
@@ -545,6 +555,16 @@ ctr_object* ctr_map_new(ctr_object* myclass, ctr_argument* argumentList) {
 	ctr_object* s = ctr_internal_create_object(CTR_OBJECT_TYPE_OTOBJECT);
 	s->link = myclass;
 	return s;
+}
+
+/**
+ * [Map] type
+ *
+ * Returns the string 'Map'.
+ *
+ **/
+ctr_object* ctr_map_type(ctr_object* myself, ctr_argument* argumentList) {
+	return ctr_build_string_from_cstring("Map");
 }
 
 /**

--- a/tests/test0231.ctr
+++ b/tests/test0231.ctr
@@ -1,0 +1,3 @@
+#test array and map type methods
+Pen write: (Array new) type, brk.
+Pen write: (Map new) type, brk.

--- a/tests/test0231.exp
+++ b/tests/test0231.exp
@@ -1,0 +1,2 @@
+Array
+Map

--- a/world.c
+++ b/world.c
@@ -718,6 +718,7 @@ void ctr_initialize_world() {
 	CtrStdArray = ctr_array_new(CtrStdObject, NULL);
 	ctr_internal_create_func(CtrStdArray, ctr_build_string_from_cstring( CTR_DICT_NEW ), &ctr_array_new );
 	ctr_internal_create_func(CtrStdArray, ctr_build_string_from_cstring( CTR_DICT_NEW_ARRAY_AND_PUSH ), &ctr_array_new_and_push );
+	ctr_internal_create_func(CtrStdArray, ctr_build_string_from_cstring( CTR_DICT_TYPE ), &ctr_array_type );
 	ctr_internal_create_func(CtrStdArray, ctr_build_string_from_cstring( CTR_DICT_PUSH ), &ctr_array_push );
 	ctr_internal_create_func(CtrStdArray, ctr_build_string_from_cstring( CTR_DICT_PUSH_SYMBOL ), &ctr_array_push );
 	ctr_internal_create_func(CtrStdArray, ctr_build_string_from_cstring( CTR_DICT_UNSHIFT ), &ctr_array_unshift );
@@ -743,7 +744,8 @@ void ctr_initialize_world() {
 
 	/* Map */
 	CtrStdMap = ctr_internal_create_object(CTR_OBJECT_TYPE_OTOBJECT);
-	ctr_internal_create_func(CtrStdMap, ctr_build_string_from_cstring( CTR_DICT_NEW), &ctr_map_new );
+	ctr_internal_create_func(CtrStdMap, ctr_build_string_from_cstring( CTR_DICT_NEW ), &ctr_map_new );
+	ctr_internal_create_func(CtrStdMap, ctr_build_string_from_cstring( CTR_DICT_TYPE ), &ctr_map_type );
 	ctr_internal_create_func(CtrStdMap, ctr_build_string_from_cstring( CTR_DICT_PUT_AT ), &ctr_map_put );
 	ctr_internal_create_func(CtrStdMap, ctr_build_string_from_cstring( CTR_DICT_AT ), &ctr_map_get );
 	ctr_internal_create_func(CtrStdMap, ctr_build_string_from_cstring( CTR_DICT_AT_SYMBOL ), &ctr_map_get );


### PR DESCRIPTION
Overrides default `type` method from `Object` with an `Array` and `Map` specific string return value.