### PR TITLE
Compatibility with Haiku

### DIFF
--- a/bin/Haiku/.gitkeep
+++ b/bin/Haiku/.gitkeep
@@ -1,0 +1,1 @@
+Used to store binaries

--- a/system.c
+++ b/system.c
@@ -1176,8 +1176,8 @@ ctr_object* ctr_clock_equals( ctr_object* myself, ctr_argument* argumentList ) {
  * ✎ write: (m = n), stop.
  */
 ctr_object* ctr_clock_neq( ctr_object* myself, ctr_argument* argumentList ) {
-	ctr_object* bool = ctr_clock_equals(myself, argumentList);
-	if (bool == CtrStdBoolTrue) return CtrStdBoolFalse;
+	ctr_object* boolean = ctr_clock_equals(myself, argumentList);
+	if (boolean == CtrStdBoolTrue) return CtrStdBoolFalse;
 	return CtrStdBoolTrue;
 }
 


### PR DESCRIPTION
Using d_type with dirents isn't POSIX, and isn't supported by Plan 9 or Haiku― switched to using lstat.
Haiku also complains when using `bool` as a name.